### PR TITLE
:ambulance: Fix bug

### DIFF
--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -188,7 +188,7 @@ trait WithFilters
                 // (e.g. consider that January 32 is February 1)
                 $dt = DateTime::createFromFormat("Y-m-d", $filterValue);
 
-                return $dt !== false && ! array_sum($dt::getLastErrors());
+                return $dt !== false && $dt::getLastErrors() === false;
             }
 
             if ($filterDefinitions[$filterName]->isDatetime()) {
@@ -197,7 +197,7 @@ trait WithFilters
                 // (e.g. consider that January 32 is February 1)
                 $dt = DateTime::createFromFormat("Y-m-d\TH:i", $filterValue);
 
-                return $dt !== false && ! array_sum($dt::getLastErrors());
+                return $dt !== false && $dt::getLastErrors() === false;
             }
 
             return false;


### PR DESCRIPTION
Since php 8.2, getLastErrors can return false, previously always returned an array (even if there are no errors).

Previous code of the array_sum was used to check if there were errors, even if there were not the array_sum would have returned 0 zo in that case it would work.

Now that it can return false, we need to check if it is false, and if not, clear the filter.